### PR TITLE
1.1.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 env:
   EXECUTABLE_NAME: evidenceangel-ui

--- a/.github/workflows/check-version-bumped.yaml
+++ b/.github/workflows/check-version-bumped.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
 
 jobs:
   check-version:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "evidenceangel"
-version = "1.1.0-rc.1"
+version = "1.1.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "serde",
@@ -2302,18 +2302,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -564,7 +564,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "evidenceangel"
-version = "1.1.0"
+version = "1.1.0-rc.1"
 dependencies = [
  "base64",
  "chrono",
@@ -590,7 +590,7 @@ dependencies = [
  "serde_json",
  "sha256",
  "sys-locale",
- "thiserror 2.0.5",
+ "thiserror 2.0.6",
  "uuid",
  "zip",
 ]
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "litemap"
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.79.4"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c743cb9f2a4524676020e26ee5f298445a82d882b09956811b1e78ca7e42b440"
+checksum = "442eafa04d985ae671e027481e07a5b70fdb1b2cb5e46d9e074b67ca98e01a0a"
 dependencies = [
  "chrono",
  "zip",
@@ -2537,11 +2537,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643caef17e3128658ff44d85923ef2d28af81bb71e0d67bbfe1d76f19a73e053"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.5",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -2557,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995d0bbc9995d1f19d28b7215a9352b0fc3cd3a2d2ec95c2cadc485cdedbcdde"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,7 +3209,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "sha1",
- "thiserror 2.0.5",
+ "thiserror 2.0.6",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evidenceangel"
 description = "Library and executables to work with EvidenceAngel evidence packages (*.evp)."
-version = "1.1.0"
+version = "1.1.0-rc.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 authors = [
@@ -71,7 +71,7 @@ relm4 = { version = "0.9.0", features = [
     "gnome_46",
 ], optional = true }
 relm4-icons = { version = "0.9.0", optional = true }
-rust_xlsxwriter = { version = "0.79.4", features = ["chrono"], optional = true }
+rust_xlsxwriter = { version = "0.80.0", features = ["chrono"], optional = true }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 sha256 = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evidenceangel"
 description = "Library and executables to work with EvidenceAngel evidence packages (*.evp)."
-version = "1.1.0-rc.1"
+version = "1.1.0"
 edition = "2021"
 license = "GPL-3.0-or-later"
 authors = [

--- a/src/evidenceangel-cli/main.rs
+++ b/src/evidenceangel-cli/main.rs
@@ -256,13 +256,14 @@ fn exec() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 EvidenceValue::File { path, caption } => {
-                    let media: MediaFile = fs::read(path)?.into();
+                    let media: MediaFile = fs::read(&path)?.into();
                     let hash = media.hash();
                     package.add_media(media)?;
                     if let Some(case) = package.test_case_mut(case_id)? {
                         let mut evidence =
                             Evidence::new(EvidenceKind::File, EvidenceData::Media { hash });
                         evidence.set_caption(caption);
+                        evidence.set_original_filename(path.file_name().map(|s| s.to_string_lossy().to_string()));
                         case.evidence_mut().push(evidence);
                     } else {
                         eprintln!("No test case exists with that ID!");

--- a/src/evidenceangel-cli/main.rs
+++ b/src/evidenceangel-cli/main.rs
@@ -263,7 +263,9 @@ fn exec() -> Result<(), Box<dyn std::error::Error>> {
                         let mut evidence =
                             Evidence::new(EvidenceKind::File, EvidenceData::Media { hash });
                         evidence.set_caption(caption);
-                        evidence.set_original_filename(path.file_name().map(|s| s.to_string_lossy().to_string()));
+                        evidence.set_original_filename(
+                            path.file_name().map(|s| s.to_string_lossy().to_string()),
+                        );
                         case.evidence_mut().push(evidence);
                     } else {
                         eprintln!("No test case exists with that ID!");

--- a/src/evidenceangel-ui/app.rs
+++ b/src/evidenceangel-ui/app.rs
@@ -1122,7 +1122,13 @@ impl Component for AppModel {
             }
             AppInput::SetMetadataDescription(new_desc) => {
                 if let Some(pkg) = self.get_package() {
-                    pkg.write().unwrap().metadata_mut().set_description(if new_desc.trim().is_empty() { None } else { Some(new_desc) });
+                    pkg.write().unwrap().metadata_mut().set_description(
+                        if new_desc.trim().is_empty() {
+                            None
+                        } else {
+                            Some(new_desc)
+                        },
+                    );
                     self.needs_saving = true;
                 }
             }

--- a/src/evidenceangel-ui/dialogs/add_evidence.rs
+++ b/src/evidenceangel-ui/dialogs/add_evidence.rs
@@ -395,7 +395,6 @@ impl Component for AddImageEvidenceDialogModel {
                     .modal(true)
                     .title(lang::lookup("header-open"))
                     .filters(&filter::filter_list(vec![filter::images()]))
-                    .initial_folder(&gtk::gio::File::for_path("."))
                     .build();
 
                 let sender_c = sender.clone();

--- a/src/evidenceangel-ui/dialogs/export.rs
+++ b/src/evidenceangel-ui/dialogs/export.rs
@@ -165,7 +165,6 @@ impl Component for ExportDialogModel {
                 let dialog = gtk::FileDialog::builder()
                     .modal(true)
                     .title(lang::lookup("header-open"))
-                    .initial_folder(&gtk::gio::File::for_path("."))
                     .initial_name(self.test_case_name.as_ref().unwrap_or(&self.package_name))
                     .accept_label(lang::lookup("select"))
                     .build();

--- a/src/exporters/excel.rs
+++ b/src/exporters/excel.rs
@@ -97,6 +97,11 @@ fn create_metadata_sheet(
         worksheet.write_string_with_format(row, 1, format!("{author}"), &italic)?;
     }
 
+    row += 2;
+    if let Some(description) = package.metadata().description() {
+        worksheet.write_string(row, 1, description)?;
+    }
+
     Ok(())
 }
 

--- a/src/exporters/excel.rs
+++ b/src/exporters/excel.rs
@@ -74,6 +74,7 @@ impl Exporter for ExcelExporter {
     }
 }
 
+/// Create the worksheet for the metadata
 fn create_metadata_sheet(
     worksheet: &mut Worksheet,
     package: &EvidencePackage,
@@ -105,6 +106,7 @@ fn create_metadata_sheet(
     Ok(())
 }
 
+/// Create the worksheet that holds the test case's information
 fn create_test_case_sheet(
     worksheet: &mut Worksheet,
     mut package: EvidencePackage,

--- a/src/exporters/html.rs
+++ b/src/exporters/html.rs
@@ -107,6 +107,7 @@ impl Exporter for HtmlExporter {
     }
 }
 
+/// Create the <div> element that holds a test case's data
 fn create_test_case_div(
     mut package: EvidencePackage,
     test_case: &TestCase,
@@ -173,6 +174,7 @@ fn create_test_case_div(
     Ok(elem)
 }
 
+/// Get the styling for this document
 fn get_style() -> CssDocument {
     let mut style = CssDocument::new();
     style.add_element(domrs::CssElement::Ruleset(

--- a/src/exporters/html.rs
+++ b/src/exporters/html.rs
@@ -51,6 +51,10 @@ impl Exporter for HtmlExporter {
                 .child(HtmlElement::new("em").content(&html_escape::encode_text(&authors))),
         );
 
+        if let Some(description) = package.metadata().description() {
+            body.add_child(HtmlElement::new("p").content(&html_escape::encode_text(description)));
+        }
+
         let mut test_cases: Vec<&TestCase> = package.test_case_iter()?.collect();
         test_cases.sort_by(|a, b| {
             a.metadata()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,21 @@
 #![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
 
 //! # EvidenceAngel
 //!
 //! EvidenceAngel is a new tool in the Angel-suite to collect test evidence
 //! from both manual and automated testing.
 
+/// The types of data in a package
 mod package;
 pub use package::{
     Author, Evidence, EvidenceData, EvidenceKind, EvidencePackage, MediaFile, Metadata, TestCase,
     TestCaseMetadata,
 };
+/// The results of this crate
 mod result;
 pub use result::{Error, Result};
 /// Exporters allow packages and test cases to be exported to different file formats.
 pub mod exporters;
+/// Open a ZIP file in a fashion that allows it to be switched between reading and writing.
 mod zip_read_writer;

--- a/src/package.rs
+++ b/src/package.rs
@@ -87,7 +87,11 @@ impl EvidencePackage {
             schema: MANIFEST_SCHEMA_LOCATION.to_string(),
             media: vec![],
             test_cases: vec![],
-            metadata: Metadata { title, description: None, authors },
+            metadata: Metadata {
+                title,
+                description: None,
+                authors,
+            },
         };
         let manifest_clone = manifest.clone_serde();
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -17,17 +17,22 @@ use zip::{result::ZipError, write::SimpleFileOptions};
 
 use crate::{result::Error, zip_read_writer::ZipReaderWriter, Result};
 
+/// Package manifests
 mod manifest;
 pub use manifest::*;
 
+/// Media handling
 mod media;
 pub use media::MediaFile;
 
+/// Test cases from packages
 mod test_cases;
 pub use test_cases::{Evidence, EvidenceData, EvidenceKind, TestCase, TestCaseMetadata};
 
+/// The URL for $schema for manifest.json
 const MANIFEST_SCHEMA_LOCATION: &str =
     "https://evidenceangel-schemas.hpkns.uk/manifest.1.schema.json";
+/// The schema to validate manifest.json against
 const MANIFEST_SCHEMA: &str = include_str!("../schemas/manifest.1.schema.json");
 
 /// An Evidence Package.
@@ -36,17 +41,22 @@ pub struct EvidencePackage {
     /// The internal ZIP file. This will never be `None`, as long as it has been correctly parsed.
     #[serde(skip)]
     zip: ZipReaderWriter,
+    /// The actual media data from this package
     #[serde(skip)]
     media_data: HashMap<String, MediaFile>,
+    /// The actual test data from this package
     #[serde(skip)]
     test_case_data: HashMap<Uuid, TestCase>,
 
+    /// The JSON schema for for this package
     #[serde(rename = "$schema")]
     schema: String,
     /// The metadata for the package.
     #[getset(get = "pub", get_mut = "pub")]
     metadata: Metadata,
+    /// The manifest entries for the media in this package
     media: Vec<MediaFileManifestEntry>,
+    /// The manifest entries for the test cases in this package
     test_cases: Vec<TestCaseManifestEntry>,
 }
 
@@ -156,6 +166,7 @@ impl EvidencePackage {
                     &serde_json::from_str(TESTCASE_SCHEMA).expect("Schema is validated statically"),
                     &serde_json::from_str(&data).expect("JSON just generated, shouldn't fail"),
                 ) {
+                    let _ = self.zip.interrupt_write();
                     return Err(Error::TestCaseSchemaValidationFailed);
                 }
                 zip.start_file(format!("testcases/{id}.json"), options)?;
@@ -217,7 +228,8 @@ impl EvidencePackage {
             &serde_json::from_str(MANIFEST_SCHEMA).expect("Schema is validated statically"),
             &serde_json::from_str(&manifest_data).expect("JSON just generated, shouldn't fail"),
         ) {
-            return Err(Error::TestCaseSchemaValidationFailed);
+            let _ = self.zip.interrupt_write();
+            return Err(Error::ManifestSchemaValidationFailed);
         }
         zip.start_file("manifest.json", options)?;
         zip.write_all(manifest_data.as_bytes())?;

--- a/src/package/manifest.rs
+++ b/src/package/manifest.rs
@@ -59,6 +59,7 @@ impl fmt::Display for Author {
     }
 }
 
+/// The manifest entry for a media file present in the package.
 #[derive(Clone, Debug, Getters, Serialize, Deserialize)]
 #[getset(get = "pub")]
 pub(super) struct MediaFileManifestEntry {
@@ -81,6 +82,8 @@ impl From<&crate::MediaFile> for MediaFileManifestEntry {
     }
 }
 
+/// An entry in the manifest storing the [`Uuid`] for a test case present in the
+/// package.
 #[derive(Clone, Debug, Getters, Serialize, Deserialize)]
 #[getset(get = "pub")]
 pub(super) struct TestCaseManifestEntry {
@@ -89,6 +92,7 @@ pub(super) struct TestCaseManifestEntry {
 }
 
 impl TestCaseManifestEntry {
+    /// Create a new test case manifest entry
     pub(super) fn new(name: Uuid) -> Self {
         Self { name }
     }

--- a/src/package/test_cases.rs
+++ b/src/package/test_cases.rs
@@ -7,13 +7,16 @@ use serde::{
 };
 use uuid::Uuid;
 
+/// The URL for $schema in the test case manifests
 const TESTCASE_SCHEMA_LOCATION: &str =
-    "https://evidenceangel-schemas.hpkns.uk/manifest.1.schema.json";
+    "https://evidenceangel-schemas.hpkns.uk/testcase.1.schema.json";
+/// The schema itself for test case manifests
 pub(crate) const TESTCASE_SCHEMA: &str = include_str!("../../schemas/testcase.1.schema.json");
 
 /// A test case stored within an [`EvidencePackage`](super::EvidencePackage).
 #[derive(Clone, Debug, Serialize, Deserialize, Getters, MutGetters, Setters)]
 pub struct TestCase {
+    /// The $schema from this test case
     #[serde(rename = "$schema")]
     schema: String,
 
@@ -32,6 +35,7 @@ pub struct TestCase {
 }
 
 impl TestCase {
+    /// Create a new test case
     pub(super) fn new(id: Uuid, title: String, execution_datetime: DateTime<FixedOffset>) -> Self {
         Self {
             schema: TESTCASE_SCHEMA_LOCATION.to_string(),
@@ -138,6 +142,8 @@ impl EvidenceData {
     }
 }
 
+/// The serde visitor for parsing evidence data values (i.e. `plain:`, `base64:`
+/// and `media:`)
 struct EvidenceDataVisitor;
 
 impl Visitor<'_> for EvidenceDataVisitor {

--- a/src/package/test_cases.rs
+++ b/src/package/test_cases.rs
@@ -70,6 +70,12 @@ pub struct Evidence {
     #[getset(get_mut = "pub", set = "pub")]
     #[serde(skip_serializing_if = "Option::is_none")]
     caption: Option<String>,
+
+    /// The original filename, if this is `File` evidence.
+    /// This MUST be None for any other kind of evidence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[getset(get_mut = "pub", set = "pub")]
+    original_filename: Option<String>,
 }
 
 impl Evidence {
@@ -79,6 +85,7 @@ impl Evidence {
             kind,
             value,
             caption: None,
+            original_filename: None,
         }
     }
 }

--- a/src/zip_read_writer.rs
+++ b/src/zip_read_writer.rs
@@ -13,9 +13,12 @@ use zip::{ZipArchive, ZipWriter};
 /// [`ZipReaderWriter::conclude_write`] is called.
 #[derive(Default, Setters)]
 pub(crate) struct ZipReaderWriter {
+    /// The path of this zip file, if set
     #[getset(set = "pub")]
     file: Option<path::PathBuf>,
+    /// The reader, if in write mode, of this reader/writer
     reader: Option<ZipArchive<BufReader<fs::File>>>,
+    /// The writer, if in write mode, of this reader/writer
     writer: Option<ZipWriter<BufWriter<fs::File>>>,
 }
 
@@ -45,6 +48,7 @@ impl fmt::Debug for ZipReaderWriter {
 }
 
 impl ZipReaderWriter {
+    /// Create a new [`ZipReaderWriter`] instance.
     pub fn new(path: path::PathBuf) -> Self {
         Self {
             file: Some(path),
@@ -52,6 +56,7 @@ impl ZipReaderWriter {
         }
     }
 
+    /// Get this [`ZipReaderWriter`] instance in read mode.
     pub fn as_reader(&mut self) -> crate::Result<&mut ZipArchive<BufReader<fs::File>>> {
         if self.reader.is_none() {
             // Close writer
@@ -69,6 +74,7 @@ impl ZipReaderWriter {
         Ok(self.reader.as_mut().unwrap())
     }
 
+    /// Get this [`ZipReaderWriter`] instance in write mode.
     #[allow(clippy::type_complexity)]
     pub fn as_writer(
         &mut self,
@@ -96,6 +102,7 @@ impl ZipReaderWriter {
         Ok((self.reader.as_mut(), self.writer.as_mut().unwrap()))
     }
 
+    /// Conclude writing to the ZIP file and reset for reading or writing again.
     pub fn conclude_write(&mut self) -> crate::Result<()> {
         if self.writer.is_some() {
             // Close write
@@ -123,6 +130,33 @@ impl ZipReaderWriter {
                     .as_ref()
                     .expect("zipreadwriter must not be called upon until file is set."),
             )?;
+        }
+        Ok(())
+    }
+
+    /// Interrupt a write early, concluding the write and removing the temporary file.
+    pub fn interrupt_write(&mut self) -> crate::Result<()> {
+        if self.writer.is_some() {
+            // Close write
+            log::debug!("Closing writer");
+            let writer = self.writer.take().unwrap();
+            writer.finish()?;
+
+            log::debug!("Closing reader");
+            self.reader = None;
+
+            // Delete temp file
+            log::debug!("Moving temp file to overwrite package");
+            let tmp_path = self
+                .file
+                .as_ref()
+                .map(|p| {
+                    let mut p = p.clone();
+                    p.set_file_name(format!("{}.tmp", p.file_name().unwrap().to_string_lossy()));
+                    p
+                })
+                .expect("zipreadwriter must not be called upon until file is set.");
+            fs::remove_file(tmp_path)?;
         }
         Ok(())
     }


### PR DESCRIPTION
> [!IMPORTANT]
> In the update to 1.1.0, schema validation has changed, and now checks if author email addresses are valid. After updating to 1.1.0, evidence packages with invalid email addresses for authors will not open. Change this in an older version (1.0.3 works) before updating! 